### PR TITLE
set up and test webconfig

### DIFF
--- a/app/entry.js
+++ b/app/entry.js
@@ -1,0 +1,3 @@
+'use strict';
+
+alert('Hellow World');

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,1 +1,24 @@
+'use strict';
 
+const HTMLPlugin = require('html-webpack-plugin');
+
+module.exports = {
+  entry: `${__dirname}/app/entry.js`,
+  output: {
+    filename: 'bundle.js',
+    path: 'build'
+  },
+  plugins: [
+    new HTMLPlugin({
+      template: `${__dirname}/app/index.html`
+    })
+  ],
+  module: {
+    loaders: [
+      {
+        test: /\.scss$/,
+        loader: 'style!css!sass!'
+      }
+    ]
+  }
+};


### PR DESCRIPTION
learned that it is not necessary to type out the entire file path to webpack inside of node_modules in order to run npm scripts.